### PR TITLE
Precompile using babel before publishing

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,8 @@ platform:
 - x64
 environment:
   matrix:
+  - nodejs_version: "0.10"
+  - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "5"
   - nodejs_version: "6"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,7 +22,7 @@ test_script:
 - npm --version
 - ps: |
       if (($env:nodejs_version -eq "0.10") -or ($env:nodejs_version -eq "0.12")) {
-        npm run internCI
+        npm run oldNodeCI
       } else {
         npm run ci
       }

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,6 +20,11 @@ install:
 test_script:
 - node --version
 - npm --version
-- npm run ci
+- ps: |
+      if (($env:nodejs_version -eq "0.10") -or ($env:nodejs_version -eq "0.12")) {
+        npm run internCI
+      } else {
+        npm run ci
+      }
 
 build: off

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+build.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 build.js
+tests/transpiled.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lcov.info
 npm-debug.log
 build.js
+tests/transpiled.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 lcov.info
+npm-debug.log
+build.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.appveyor.yml
+.codeclimate.yml
+.editorconfig
+.npmignore
+.travis.yml
+index.js
+tests

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,7 @@
 .appveyor.yml
 .codeclimate.yml
 .editorconfig
+.eslintignore
 .npmignore
 .travis.yml
 index.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 script:
 - |
   if [[ ${TRAVIS_NODE_VERSION:0:1} = "0" ]]; then
-    npm run internCI
+    npm run oldNodeCI
   else
     npm run ci
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
 osx_image: xcode8
 language: node_js
 node_js:
+- '0.10'
+- '0.12'
 - '4'
 - '5'
 - '6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,10 @@ cache:
 env:
   global:
   - CODECLIMATE_REPO_TOKEN=f38fa2f1de8a3a776fe3587f9eef2df022f9822241563e4df82cbc9ab3d7997b
-script: npm run ci
+script:
+- |
+  if [[ ${TRAVIS_NODE_VERSION:0:1} = "0" ]]; then
+    npm run internCI
+  else
+    npm run ci
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ node_js:
 cache:
   directories:
   - node_modules
-addons:
-  code_climate:
-    repo_token: f38fa2f1de8a3a776fe3587f9eef2df022f9822241563e4df82cbc9ab3d7997b
+env:
+  global:
+  - CODECLIMATE_REPO_TOKEN=f38fa2f1de8a3a776fe3587f9eef2df022f9822241563e4df82cbc9ab3d7997b
 script: npm run ci

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const debug = require('debug')('sumchecker')
 const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
+const Promise = global.Promise || require('es6-promise').Promise
 
 const CHECKSUM_LINE = /^([\da-fA-F]+) ([ *])(.+)$/
 

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "es6-promise": "^3.2.1"
   },
   "scripts": {
-    "ci": "eslint . && npm run internCI",
-    "internCI": "intern-client config=tests/intern reporters=Lcov reporters=Console && codeclimate-test-reporter < lcov.info",
+    "ci": "eslint . && intern-client config=tests/intern suites=tests/index reporters=Lcov reporters=Console && codeclimate-test-reporter < lcov.info",
+    "oldNodeCI": "babel --out-file tests/transpiled.js tests/index.js && intern-client config=tests/intern suites=tests/transpiled reporters=Console",
     "prepublish": "babel --out-file build.js index.js",
-    "test": "eslint . && intern-client config=tests/intern reporters=Pretty"
+    "test": "eslint . && intern-client config=tests/intern suites=tests/index reporters=Pretty"
   },
   "eslintConfig": {
     "env": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "es6-promise": "^3.2.1"
   },
   "scripts": {
-    "ci": "eslint . && intern-client config=tests/intern reporters=Lcov reporters=Console && codeclimate-test-reporter < lcov.info",
+    "ci": "eslint . && npm run internCI",
+    "internCI": "intern-client config=tests/intern reporters=Lcov reporters=Console && codeclimate-test-reporter < lcov.info",
     "prepublish": "babel --out-file build.js index.js",
     "test": "eslint . && intern-client config=tests/intern reporters=Pretty"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "nyc": "^8.1.0"
   },
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "es6-promise": "^3.2.1"
   },
   "scripts": {
     "ci": "eslint . && intern-client config=tests/intern reporters=Lcov reporters=Console && codeclimate-test-reporter < lcov.info",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Mark Lee",
   "license": "Apache-2.0",
   "description": "Checksum validator",
-  "main": "index.js",
+  "main": "build.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/malept/sumchecker.git"
@@ -18,6 +18,9 @@
   },
   "homepage": "https://github.com/malept/sumchecker#readme",
   "devDependencies": {
+    "babel-cli": "^6.14.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-register": "^6.14.0",
     "codeclimate-test-reporter": "^0.3.3",
     "eslint": "^3.3.1",
     "eslint-config-standard": "^6.0.0-beta.3",
@@ -31,6 +34,7 @@
   },
   "scripts": {
     "ci": "eslint . && intern-client config=tests/intern reporters=Lcov reporters=Console && codeclimate-test-reporter < lcov.info",
+    "prepublish": "babel --out-file build.js index.js",
     "test": "eslint . && intern-client config=tests/intern reporters=Pretty"
   },
   "eslintConfig": {
@@ -46,5 +50,10 @@
         "error"
       ]
     }
+  },
+  "babel": {
+    "presets": [
+      "es2015"
+    ]
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -34,15 +34,9 @@ define((require) => {
     return sumchecker('sha256', fixture(checksumFilename), fixture(''), filesToCheck)
   }
 
-  const nodeVersionInfo = process.versions.node.split('.').map(function (n) { return Number(n) })
-  const isOldNode = nodeVersionInfo < [4, 0, 0]
-
   let assertError = (error, errorClass) => {
-    if (isOldNode) {
-      assert.instanceOf(error, Error)
-    } else {
-      assert.instanceOf(error, errorClass)
-    }
+    // Because of transpiling, Error subclasses don't actually work
+    assert.instanceOf(error, Error)
   }
 
   registerSuite({

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -1,6 +1,5 @@
 'use strict'
 
 define({
-  excludeInstrumentation: /^(?:tests|node_modules)\//,
-  suites: ['tests/index']
+  excludeInstrumentation: /^(?:tests|node_modules)\//
 })


### PR DESCRIPTION
This pull requests publishes a babel-ified version of `index.js` so this module can be used in old node versions that don't support ES6 stuff.

Also adds a dependency on `es6-promise` that will be a fallback when `global.Promise` is missing.

Refs https://github.com/electron-userland/electron-download/pull/30