### PR TITLE
Explicitly set default encoding in createHash()

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ class ChecksumValidator {
       let fullPath = path.resolve(baseDir, filename)
       debug(`Reading file with "${this.encoding(binary)}" encoding`)
       let stream = fs.createReadStream(fullPath, {encoding: this.encoding(binary)})
-      let hasher = crypto.createHash(this.algorithm)
+      let hasher = crypto.createHash(this.algorithm, {defaultEncoding: 'binary'})
       hasher.on('readable', () => {
         let data = hasher.read()
         if (data) {


### PR DESCRIPTION
Up until now, the default encoding for this is `binary`, but this is scheduled to change in Node 8. Since this module is currently always passing string input to the `Hash` object, it needs to account for that.

A better fix would likely involve dropping all strings handling and treating binary data using Buffer objects, but I kept this change minimal to avoid any breakage.

Refs: https://github.com/nodejs/node/pull/8611

@malept Could you backport this change to the 1.x.x versions of `sumchecker`? This came up because a major dependent of sumchecker, `electron-prebuilt`, would be affected by the change in Node, and it still supports 0.10.x/0.12.x Node versions.