### PR TITLE
v1.x: Explicitly set default encoding in createHash()

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ class ChecksumValidator {
       let fullPath = path.resolve(baseDir, filename)
       debug(`Reading file with "${this.encoding(binary)}" encoding`)
       let stream = fs.createReadStream(fullPath, {encoding: this.encoding(binary)})
-      let hasher = crypto.createHash(this.algorithm)
+      let hasher = crypto.createHash(this.algorithm, {defaultEncoding: 'binary'})
       hasher.on('readable', () => {
         let data = hasher.read()
         if (data) {


### PR DESCRIPTION
Backport PR for https://github.com/malept/sumchecker/pull/5 (which does cherry-pick cleanly, btw)