### PR TITLE
Allow null as defaultTextEncoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class ChecksumValidator {
     this.checksumFilename = checksumFilename
     this.checksums = null
 
-    if (options && options.hasOwnProperty("defaultTextEncoding")) {
+    if (options && options.hasOwnProperty('defaultTextEncoding')) {
       this.defaultTextEncoding = options.defaultTextEncoding
     } else {
       this.defaultTextEncoding = 'utf8'

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class ChecksumValidator {
     this.checksumFilename = checksumFilename
     this.checksums = null
 
-    if (options && options.defaultTextEncoding) {
+    if (options && options.hasOwnProperty("defaultTextEncoding")) {
       this.defaultTextEncoding = options.defaultTextEncoding
     } else {
       this.defaultTextEncoding = 'utf8'


### PR DESCRIPTION
Hello,

Thanks for the lib, it is very useful.
The default encoding for `createReadStream` is null.

The current check `if (options && options.defaultTextEncoding)` will never return true if `defaultTextEncoding` is null.

Therefore, null cannot be passed to `createReadStream`.

The PR fixes that.
I wonder if this should be the default ? In your usage, do you really use `encoding: utf-8` ?