### PR TITLE
refactor: convert library code to Node 8+

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ const debug = require('debug')('sumchecker')
 const crypto = require('crypto')
 const fs = require('fs')
 const path = require('path')
+const { promisify } = require('util')
+
+fs.readFile = promisify(fs.readFile)
 
 const CHECKSUM_LINE = /^([\da-fA-F]+) ([ *])(.+)$/
 
@@ -69,77 +72,59 @@ class ChecksumValidator {
   }
 
   parseChecksumFile (data) {
-    let that = this
-    return new Promise((resolve, reject) => {
-      debug('Parsing checksum file')
-      that.checksums = {}
-      let lineNumber = 0
-      data.trim().split(/[\r\n]+/).forEach(line => {
-        lineNumber += 1
-        let result = CHECKSUM_LINE.exec(line)
-        if (result === null) {
-          debug(`Could not parse line number ${lineNumber}`)
-          reject(new ChecksumParseError(lineNumber, line))
-        } else {
-          // destructuring isn't available until Node 6
-          let filename = result[3]
-          let isBinary = result[2] === '*'
-          let checksum = result[1]
+    debug('Parsing checksum file')
+    this.checksums = {}
+    let lineNumber = 0
+    for (const line of data.trim().split(/[\r\n]+/)) {
+      lineNumber += 1
+      const result = CHECKSUM_LINE.exec(line)
+      if (result === null) {
+        debug(`Could not parse line number ${lineNumber}`)
+        throw new ChecksumParseError(lineNumber, line)
+      } else {
+        result.shift()
+        const [checksum, binaryMarker, filename] = result
+        const isBinary = binaryMarker === '*'
 
-          that.checksums[filename] = [checksum, isBinary]
-        }
-      })
-      debug('Parsed checksums:', that.checksums)
-      resolve()
-    })
+        this.checksums[filename] = [checksum, isBinary]
+      }
+    }
+    debug('Parsed checksums:', this.checksums)
   }
 
-  readFile (filename, binary) {
+  async readFile (filename, binary) {
     debug(`Reading "${filename} (binary mode: ${binary})"`)
-    return new Promise((resolve, reject) => {
-      fs.readFile(filename, this.encoding(binary), (err, data) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(data)
-        }
-      })
-    })
+    return fs.readFile(filename, this.encoding(binary))
   }
 
-  validate (baseDir, filesToCheck) {
+  async validate (baseDir, filesToCheck) {
     if (typeof filesToCheck === 'string') {
       filesToCheck = [filesToCheck]
     }
 
-    return this.readFile(this.checksumFilename, false)
-      .then(this.parseChecksumFile.bind(this))
-      .then(() => {
-        return this.validateFiles(baseDir, filesToCheck)
-      })
+    const data = await this.readFile(this.checksumFilename, false)
+    this.parseChecksumFile(data)
+    return this.validateFiles(baseDir, filesToCheck)
   }
 
-  validateFile (baseDir, filename) {
+  async validateFile (baseDir, filename) {
     return new Promise((resolve, reject) => {
       debug(`validateFile: ${filename}`)
 
-      let metadata = this.checksums[filename]
+      const metadata = this.checksums[filename]
       if (!metadata) {
         return reject(new NoChecksumFoundError(filename))
       }
 
-      // destructuring isn't available until Node 6
-      let checksum = metadata[0]
-      let binary = metadata[1]
-
-      let fullPath = path.resolve(baseDir, filename)
+      const [checksum, binary] = metadata
+      const fullPath = path.resolve(baseDir, filename)
       debug(`Reading file with "${this.encoding(binary)}" encoding`)
-      let stream = fs.createReadStream(fullPath, { encoding: this.encoding(binary) })
-      let hasher = crypto.createHash(this.algorithm, { defaultEncoding: 'binary' })
+      const stream = fs.createReadStream(fullPath, { encoding: this.encoding(binary) })
+      const hasher = crypto.createHash(this.algorithm, { defaultEncoding: 'binary' })
       hasher.on('readable', () => {
-        let data = hasher.read()
+        const data = hasher.read()
         if (data) {
-          let calculated = data.toString('hex')
+          const calculated = data.toString('hex')
 
           debug(`Expected checksum: ${checksum}; Actual: ${calculated}`)
           if (calculated === checksum) {
@@ -153,15 +138,12 @@ class ChecksumValidator {
     })
   }
 
-  validateFiles (baseDir, filesToCheck) {
-    let that = this
-    return Promise.all(filesToCheck.map((filename) => {
-      return that.validateFile(baseDir, filename)
-    }))
+  async validateFiles (baseDir, filesToCheck) {
+    return Promise.all(filesToCheck.map(filename => this.validateFile(baseDir, filename)))
   }
 }
 
-let sumchecker = function sumchecker (algorithm, checksumFilename, baseDir, filesToCheck) {
+const sumchecker = async function sumchecker (algorithm, checksumFilename, baseDir, filesToCheck) {
   return new ChecksumValidator(algorithm, checksumFilename).validate(baseDir, filesToCheck)
 }
 


### PR DESCRIPTION
Use Node 8+ syntax, including async/await and destructured variables (from Node 6+). A continuation of #10.