### PR TITLE
fix: correctly export symbols in TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,34 +14,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export type ChecksumOptions = {
-  defaultTextEncoding?: string;
-};
+declare function sumchecker(algorithm: string, checksumFilename: string, baseDir: string, filesToCheck: string[] | string): Promise<void>;
 
-export default function sumchecker(algorithm: string, checksumFilename: string, baseDir: string, filesToCheck: string[] | string): Promise<void>;
+declare namespace sumchecker {
+  type ChecksumOptions = {
+    defaultTextEncoding?: string;
+  };
 
-export class ErrorWithFilename extends Error {
-  constructor(filename: string);
+  class ErrorWithFilename extends Error {
+    constructor(filename: string);
+  }
+
+  class ChecksumMismatchError extends ErrorWithFilename {
+    constructor(filename: string);
+  }
+
+  class ChecksumParseError extends Error {
+    constructor(lineNumber: number, line: string);
+  }
+
+  class NoChecksumFoundError extends ErrorWithFilename {
+    constructor(filename: string);
+  }
+
+  class ChecksumValidator {
+    constructor(algorithm: string, checksumFilename: string, options?: ChecksumOptions);
+    encoding(binary: boolean): string;
+    parseChecksumFile(data: string): void;
+    readFile(filename: string, binary: boolean): Promise<string>;
+    validate(baseDir: string, filesToCheck: string[] | string): Promise<void>;
+    validateFile(baseDir: string, filename: string): Promise<void>;
+    validateFiles(baseDir: string, filesToCheck: string[]): Promise<void>;
+  }
 }
 
-export class ChecksumMismatchError extends ErrorWithFilename {
-  constructor(filename: string);
-}
-
-export class ChecksumParseError extends Error {
-  constructor(lineNumber: number, line: string);
-}
-
-export class NoChecksumFoundError extends ErrorWithFilename {
-  constructor(filename: string);
-}
-
-export class ChecksumValidator {
-  constructor(algorithm: string, checksumFilename: string, options?: ChecksumOptions);
-  encoding(binary: boolean): string;
-  parseChecksumFile(data: string): void;
-  readFile(filename: string, binary: boolean): Promise<string>;
-  validate(baseDir: string, filesToCheck: string[] | string): Promise<void>;
-  validateFile(baseDir: string, filename: string): Promise<void>;
-  validateFiles(baseDir: string, filesToCheck: string[]): Promise<void>;
-}
+export = sumchecker

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,19 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import sumchecker = require('.');
+import * as sumchecker from '.';
+import { ChecksumParseError, ChecksumValidator } from '.';
 
-(async () => {
-  await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', 'example');
-  await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', ['example']);
-  try {
-    await sumchecker('sha256', 'test/fixture/invalid.sha256sum', 'test/fixture', ['example']);
-  } catch (error) {
-    if (!(error instanceof sumchecker.ChecksumParseError)) {
-      throw new Error('Does not throw ChecksumParseError correctly');
-    }
+await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', 'example');
+await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', ['example']);
+try {
+  await sumchecker('sha256', 'test/fixture/invalid.sha256sum', 'test/fixture', ['example']);
+} catch (error) {
+  if (!(error instanceof ChecksumParseError)) {
+    throw new Error('Does not throw ChecksumParseError correctly');
   }
+}
 
-  const validator = new sumchecker.ChecksumValidator('sha256', 'test/fixture/example.sha256sum')
-  await validator.validate('test/fixture', 'example')
-})
+const validator = new ChecksumValidator('sha256', 'test/fixture/example.sha256sum')
+await validator.validate('test/fixture', 'example')

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -14,17 +14,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import sumchecker, { ChecksumParseError, ChecksumValidator } from '.';
+import sumchecker = require('.');
 
-await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', 'example');
-await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', ['example']);
-try {
-  await sumchecker('sha256', 'test/fixture/invalid.sha256sum', 'test/fixture', ['example']);
-} catch (error) {
-  if (!(error instanceof ChecksumParseError)) {
-    throw new Error('Does not throw ChecksumParseError correctly');
+(async () => {
+  await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', 'example');
+  await sumchecker('sha256', 'test/fixture/example.sha256sum', 'test/fixture', ['example']);
+  try {
+    await sumchecker('sha256', 'test/fixture/invalid.sha256sum', 'test/fixture', ['example']);
+  } catch (error) {
+    if (!(error instanceof sumchecker.ChecksumParseError)) {
+      throw new Error('Does not throw ChecksumParseError correctly');
+    }
   }
-}
 
-const validator = new ChecksumValidator('sha256', 'test/fixture/example.sha256sum')
-await validator.validate('test/fixture', 'example')
+  const validator = new sumchecker.ChecksumValidator('sha256', 'test/fixture/example.sha256sum')
+  await validator.validate('test/fixture', 'example')
+})


### PR DESCRIPTION
This fixes https://github.com/malept/sumchecker/issues/13.