### PR TITLE
docs: rename default export via typedoc plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "source-map-support": "^0.5.16",
     "ts-node": "^10.0.0",
     "typedoc": "^0.22.3",
+    "typedoc-plugin-rename-defaults": "^0.6.4",
     "typescript": "~4.7.2"
   },
   "ava": {


### PR DESCRIPTION
Uses [`typedoc-plugin-rename-defaults`](https://www.npmjs.com/package/typedoc-plugin-rename-defaults) to restore the original function name.

----

Before:
![image](https://user-images.githubusercontent.com/11417/180584635-b503a7a8-fc45-4531-8766-26bbe2406299.png)

After:
![image](https://user-images.githubusercontent.com/11417/180584655-ca0f419b-3fd7-4640-8a1a-aa3199932ab8.png)
